### PR TITLE
Fix 'modules' error in case there is only main station module configured

### DIFF
--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -26,6 +26,8 @@ class WeatherStationData:
         self.stations = { d['_id'] : d for d in self.rawData }
         self.modules = dict()
         for i in range(len(self.rawData)):
+            if 'modules' not in self.rawData[i]:
+                self.rawData[i]['modules'] = [ self.rawData[i] ]
             for m in self.rawData[i]['modules']:
                 if 'module_name' not in m:
                     continue


### PR DESCRIPTION
By default, the https://dev.netatmo.com/resources/technical/reference/weather/getstationsdata API should return **modules** array as part of devices list. However, if there is only one main station registered (i.e. no outdoor or other modules registered) the modules array is not presented in the result of the API call. That leads to error like:

`2018-06-04 00:16:15 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up platform netatmo
Traceback (most recent call last):
  File "/usr/src/app/homeassistant/helpers/entity_platform.py", line 129, in _async_setup_platform
    SLOW_SETUP_MAX_WAIT, loop=hass.loop)
  File "/usr/local/lib/python3.6/asyncio/tasks.py", line 358, in wait_for
    return fut.result()
  File "/usr/local/lib/python3.6/concurrent/futures/thread.py", line 56, in run
    result = self.fn(*self.args, **self.kwargs)
  File "/usr/src/app/homeassistant/components/sensor/netatmo.py", line 84, in setup_platform
    for module_name in data.get_module_names():
  File "/usr/src/app/homeassistant/components/sensor/netatmo.py", line 292, in get_module_names
    self.update()
  File "/usr/src/app/homeassistant/util/__init__.py", line 319, in wrapper
    result = method(*args, **kwargs)
  File "/usr/src/app/homeassistant/components/sensor/netatmo.py", line 299, in update
    self.station_data = lnetatmo.WeatherStationData(self.auth)
  File "/usr/local/lib/python3.6/site-packages/smart_home/WeatherStation.py", line 29, in __init__
    for m in self.rawData[i]['modules']:
KeyError: 'modules'`

Example of returned JSON from API:
`{  
   "body":{  
      "devices":[  
         {  
            "_id":"70:ee:50:xx:xx:xx",
           "cipher_id":"enc:16:xxx",
            "date_setup":1498423899,
            "last_setup":1498423899,
            "type":"NAMain",
            "last_status_store":1531761786,
            "module_name":"Bedroom",
            "firmware":132,
            "last_upgrade":1498423902,
            "wifi_status":60,
            "co2_calibrating":false,
            "station_name":"Nikolaevskaya",
            "data_type":[  
               "Temperature",
               "CO2",
               "Humidity",
               "Noise",
               "Pressure"
            ],
            "place":{  
               "altitude":132,
               "city":"Xyz",
               "country":"BY",
               "timezone":"Europe\/Minsk",
               "location":[  
                  1.1,
                  1.1
               ]
            },
            "dashboard_data":{  
               "time_utc":1531761772,
               "Temperature":25.9,
               "CO2":550,
               "Humidity":61,
               "Noise":43,
               "Pressure":1004,
               "AbsolutePressure":988.4,
               "min_temp":24.4,
               "max_temp":26,
               "date_min_temp":1531688400,
               "date_max_temp":1531760867,
               "temp_trend":"stable",
               "pressure_trend":"stable"
            }
         }
      ],
      "user":{  
         "mail":"xxx@xxx.com",
         "administrative":{  
            "lang":"ru-RU",
            "reg_locale":"ru-US",
            "unit":0,
            "windunit":0,
            "pressureunit":0,
            "feel_like_algo":0
         }
      }
   },
   "status":"ok",
   "time_exec":0.076269149780273,
   "time_server":1531762021
}`
