### PR TITLE
Additional publicdata measures

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import setuptools
 
 setup(
     name='pyatmo',
-    version='1.1.1',  # Should be updated with new versions
+    version='1.2',  # Should be updated with new versions
     author='Hugo Dupras',
     author_email='jabesq@gmail.com',
     py_modules=['pyatmo'],

--- a/smart_home/PublicData.py
+++ b/smart_home/PublicData.py
@@ -1,9 +1,9 @@
 """
 coding=utf-8
 """
-import warnings, time
+import time
 
-from . import NoDevice, postRequest, todayStamps, _BASE_URL                                                                                                                 
+from . import postRequest, _BASE_URL
 
 _GETPUBLIC_DATA = _BASE_URL + "api/getpublicdata"
 _LON_NE = 6.221652
@@ -11,80 +11,160 @@ _LAT_NE = 46.610870
 _LON_SW = 6.217828
 _LAT_SW = 46.596485
 
+_STATION_TEMPERATURE_TYPE = "temperature"
+_STATION_PRESSURE_TYPE = "pressure"
+_STATION_HUMIDITY_TYPE = "humidity"
+
+_ACCESSORY_RAIN_LIVE_TYPE = "rain_live"
+_ACCESSORY_RAIN_60MIN_TYPE = "rain_60min"
+_ACCESSORY_RAIN_24H_TYPE = "rain_24h"
+_ACCESSORY_RAIN_TIME_TYPE = "rain_timeutc"
+_ACCESSORY_WIND_STRENGTH_TYPE = "wind_strength"
+_ACCESSORY_WIND_ANGLE_TYPE = "wind_angle"
+_ACCESSORY_WIND_TIME_TYPE = "wind_timeutc"
+_ACCESSORY_GUST_STRENGTH_TYPE = "gust_strength"
+_ACCESSORY_GUST_ANGLE_TYPE = "gust_angle"
+
+
 class PublicData:
 
     def __init__(self,
-                authData,
-                LAT_NE = _LAT_NE,
-                LON_NE = _LON_NE,
-                LAT_SW = _LAT_SW,
-                LON_SW=_LON_SW,
-                required_data_type = "rain", # "humidity" is the only 2nd choice
-                filtering=False):                                                                                                                                                   
-        self.getAuthToken = authData.accessToken
-        postParams = {
-            "access_token" : self.getAuthToken,
-            "lat_ne" : LAT_NE,
-            "lon_ne" : LON_NE,
-            "lat_sw" : LAT_SW,
-            "lon_sw" : LON_SW,
-            "required_data" : required_data_type,
-            "filter" : filtering
+                 auth_data,
+                 LAT_NE=_LAT_NE,
+                 LON_NE=_LON_NE,
+                 LAT_SW=_LAT_SW,
+                 LON_SW=_LON_SW,
+                 required_data_type=None,  # comma-separated list from above _STATION or _ACCESSORY values
+                 filtering=False):
+        self.getAuthToken = auth_data.accessToken
+        post_params = {
+            "access_token": self.getAuthToken,
+            "lat_ne": LAT_NE,
+            "lon_ne": LON_NE,
+            "lat_sw": LAT_SW,
+            "lon_sw": LON_SW,
+            "filter": filtering
             }
-        resp = postRequest(_GETPUBLIC_DATA, postParams)
-        self.rawData = resp['body']
+
+        if required_data_type:
+            post_params['required_data'] = required_data_type
+
+        resp = postRequest(_GETPUBLIC_DATA, post_params)
+        self.raw_data = resp['body']
         self.status = resp['status']
         self.time_exec = toTimeString(resp['time_exec'])
         self.time_server = toTimeString(resp['time_server'])
 
-
     def CountStationInArea(self):
-        return len(self.rawData)
+        return len(self.raw_data)
 
-    def get24h(self):
-        measures = {} # dict
-        for station in self.rawData:
-            for module in station['measures']:
-                for typeModule in station['measures'][module]:
-                    if typeModule == 'rain_24h':
-                        measures[station['_id']] = station['measures'][module]['rain_24h']
-        return measures
-
-
-    def get60min(self):
-        measures = {} # dict
-        for station in self.rawData:
-            for module in station['measures']:
-                for typeModule in station['measures'][module]:
-                    if typeModule == 'rain_60min':
-                        measures[station['_id']] = station['measures'][module]['rain_60min']
-        return measures
-
+    # Backwards compatibility for < 1.2
     def getLive(self):
-        measures = {} # dict
-        for station in self.rawData:
-            for module in station['measures']:
-                for typeModule in station['measures'][module]:
-                    if typeModule == 'rain_live':
-                        measures[station['_id']] = station['measures'][module]['rain_live']
-        return measures
+        return self.getLatestRain()
+
+    def getLatestRain(self):
+        return self.getAccessoryMeasures(_ACCESSORY_RAIN_LIVE_TYPE)
+
+    def getAverageRain(self):
+        return averageMeasure(self.getLatestRain())
+
+    # Backwards compatibility for < 1.2
+    def get60min(self):
+        return self.get60minRain()
+
+    def get60minRain(self):
+        return self.getAccessoryMeasures(_ACCESSORY_RAIN_60MIN_TYPE)
+
+    def getAverage60minRain(self):
+        return averageMeasure(self.get60minRain())
+
+    # Backwards compatibility for < 1.2
+    def get24h(self):
+        return self.get24hRain()
+
+    def get24hRain(self):
+        return self.getAccessoryMeasures(_ACCESSORY_RAIN_24H_TYPE)
+
+    def getAverage24hRain(self):
+        return averageMeasure(self.get24hRain())
+
+    def getLatestPressures(self):
+        return self.getLatestStationMeasures(_STATION_PRESSURE_TYPE)
+
+    def getAveragePressure(self):
+        return averageMeasure(self.getLatestPressures())
+
+    def getLatestTemperatures(self):
+        return self.getLatestStationMeasures(_STATION_TEMPERATURE_TYPE)
+
+    def getAverageTemperature(self):
+        return averageMeasure(self.getLatestTemperatures())
+
+    def getLatestHumidities(self):
+        return self.getLatestStationMeasures(_STATION_HUMIDITY_TYPE)
+
+    def getAverageHumidity(self):
+        return averageMeasure(self.getLatestHumidities())
+
+    def getLatestWindStrengths(self):
+        return self.getAccessoryMeasures(_ACCESSORY_WIND_STRENGTH_TYPE)
+
+    def getAverageWindStrength(self):
+        return averageMeasure(self.getLatestWindStrengths())
+
+    def getLatestWindAngles(self):
+        return self.getAccessoryMeasures(_ACCESSORY_WIND_ANGLE_TYPE)
+
+    def getLatestGustStrengths(self):
+        return self.getAccessoryMeasures(_ACCESSORY_GUST_STRENGTH_TYPE)
+
+    def getAverageGustStrength(self):
+        return averageMeasure(self.getLatestGustStrengths())
+
+    def getLatestGustAngles(self):
+        return self.getAccessoryMeasures(_ACCESSORY_GUST_ANGLE_TYPE)
 
     def getLocations(self):
-        locations = {} #dict
-        for station in self.rawData:
-            locations [station['_id']] = station['place']['location']
+        locations = {}
+        for station in self.raw_data:
+            locations[station['_id']] = station['place']['location']
         return locations
 
+    # Backwards compatibility for < 1.2
     def getTimeforMeasure(self):
-        measures_timestamps = {} # dict
-        for station in self.rawData:
-            for module in station['measures']:
-                for typeModule in station['measures'][module]:
-                    if typeModule == 'rain_timeutc':            
-                        measures_timestamps[station['_id']] = station['measures'][module]['rain_timeutc']
-        return measures_timestamps
+        return self.getTimeForRainMeasures()
 
+    def getTimeForRainMeasures(self):
+        return self.getAccessoryMeasures(_ACCESSORY_RAIN_TIME_TYPE)
+
+    def getTimeForWindMeasures(self):
+        return self.getAccessoryMeasures(_ACCESSORY_WIND_TIME_TYPE)
+
+    def getLatestStationMeasures(self, type):
+        measures = {}
+        for station in self.raw_data:
+            for _, module in station['measures'].items():
+                if 'type' in module and type in module['type'] and 'res' in module and module['res']:
+                    measure_index = module['type'].index(type)
+                    latest_timestamp = sorted(module['res'], reverse=True)[0]
+                    measures[station['_id']] = module['res'][latest_timestamp][measure_index]
+        return measures
+
+    def getAccessoryMeasures(self, type):
+        measures = {}
+        for station in self.raw_data:
+            for _, module in station['measures'].items():
+                if type in module:
+                    measures[station['_id']] = module[type]
+        return measures
 
 
 def toTimeString(value):
     return time.strftime("%Y-%m-%d_%H:%M:%S", time.localtime(int(value)))
+
+
+def averageMeasure(measures):
+    if measures:
+        return sum(measures.values()) / len(measures)
+    else:
+        return 0.0


### PR DESCRIPTION
Extended the GetPublicData API to support the following measures in addition to rain:

- temperature
- pressure
- humidity
- wind_strength
- wind_angle
- wind_timeutc
- gust_strength
- gust_angle

This PR renames all the API methods in this file to indicate the measure they are retrieving although have retained the original `getLive()`, `get24h()`, `get60min()`  and ```getTimeforMeasure()``` for backwards compatibility.

This PR also splits the measures into two distinct types "station" and "accessory" - station indicating they come from the original Netatmo weather station and accessory to indicate they come from either the rain or anemometer units. This is important as the data returned in the GetPublicData API is different. e.g:
```
{
    'res': {
        '1536357836': [12.7, 63]
    },
    'type': ['temperature', 'humidity']
}
```
compared to:
```
{
    'rain_60min': 0,
    'rain_24h': 0.101,
    'rain_live': 0,
    'rain_timeutc': 1536357829
}
```
Additionally, the wrapper now includes methods to get a single average value for each measure to ease end users who just want a simple way to get a single value for an area. The only exception to this is the wind/gust angle measures - the data is not clean enough for an average to be useful.

Bumped to version 1.2 to indicate the additions but no API changes.

p.s. HomeAssistant fans - The whole purpose of this PR is so that I can extend the support of the new Netatmo Public Sensor :)