### PR TITLE
Add support for HomeCoach

### DIFF
--- a/pyatmo.py
+++ b/pyatmo.py
@@ -16,6 +16,7 @@ from smart_home.WeatherStation import WeatherStationData, DeviceList
 from smart_home.Camera import CameraData
 from smart_home.Thermostat import ThermostatData
 from smart_home.PublicData import PublicData
+from smart_home.HomeCoach import HomeCoachData
 from smart_home import _BASE_URL, postRequest, NoDevice
 
 ######################## USER SPECIFIC INFORMATION ######################

--- a/smart_home/HomeCoach.py
+++ b/smart_home/HomeCoach.py
@@ -1,0 +1,18 @@
+"""
+coding=utf-8
+"""
+from .WeatherStation import WeatherStationData
+
+from . import _BASE_URL
+
+_GETHOMECOACHDATA_REQ = _BASE_URL + "api/gethomecoachsdata"
+
+
+class HomeCoachData(WeatherStationData):
+    """
+    List the Home Couch devices (stations and modules)
+    Args:
+        authData (ClientAuth): Authentication information with a working access Token
+    """
+    def __init__(self, authData):
+       super(HomeCoachData, self).__init__(authData, urlReq=_GETHOMECOACHDATA_REQ)

--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -18,7 +18,7 @@ class WeatherStationData:
         self.urlReq = urlReq or _GETMEASURE_REQ
         self.getAuthToken = authData.accessToken
         postParams = {
-                "access_token" : self.getAuthToken
+                "access_token": self.getAuthToken
                 }
         resp = postRequest(self.urlReq, postParams)
         self.rawData = resp['body']['devices']
@@ -36,13 +36,13 @@ class WeatherStationData:
         self.default_station = list(self.stations.values())[0]['station_name']
 
     def modulesNamesList(self, station=None):
-        res = [m['module_name'] for m in self.modules.values()]
+        res = set([m['module_name'] for m in self.modules.values()])
         if station:
-            res.append(self.stationByName(station)['module_name'])
+            res.add(self.stationByName(station)['module_name'])
         else:
             for id,station in self.stations.items():
-                res.append(station['module_name'])
-        return res
+                res.add(station['module_name'])
+        return list(res)
 
     def stationByName(self, station=None):
         if not station : station = self.default_station

--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -14,12 +14,13 @@ class WeatherStationData:
     Args:
         authData (ClientAuth): Authentication information with a working access Token
     """
-    def __init__(self, authData):
+    def __init__(self, authData, urlReq=None):
+        self.urlReq = urlReq or _GETMEASURE_REQ
         self.getAuthToken = authData.accessToken
         postParams = {
                 "access_token" : self.getAuthToken
                 }
-        resp = postRequest(_GETSTATIONDATA_REQ, postParams)
+        resp = postRequest(self.urlReq, postParams)
         self.rawData = resp['body']['devices']
         if not self.rawData : raise NoDevice("No weather station available")
         self.stations = { d['_id'] : d for d in self.rawData }


### PR DESCRIPTION
Hi!

This PR brings support for the netatmo HomeCoach module. It is basically a weather station limited, but works almost the same, but using a different URL endpoint. I want to enable this module in home assistant so would be nice if we can merge this.

Here is the [official api](https://dev.netatmo.com/resources/technical/reference/common/getmeasure)

I've tried with my module:

```python
        hc = HomeCoachData(authorization)      
        print(hc.lastData(station="salon"))
```

It retrieves the data correctly:

```
{'Indoor': {'Temperature': 22.2, 'CO2': 267, 'Humidity': 53, 'Noise': 56, 'Pressure': 1023.4, 'AbsolutePressure': 944.7, 'health_idx': 0, 'min_temp': 22.2, 'max_temp': 23.3, 'date_min_temp': 1541326810, 'date_max_temp': 1541286118, 'When': 1541327414}}
```

A new scope is needed in order to get the data:

```
scope="read_homecoach"
```