### PR TITLE
Fix wrong setpoint read from endpoint in manual setpoint mode

### DIFF
--- a/smart_home/Thermostat.py
+++ b/smart_home/Thermostat.py
@@ -29,8 +29,11 @@ class ThermostatData:
         self.modList = self.devList[0]['modules']
         self.modId = self.modList[0]['_id']
         self.temp = self.modList[0]['measured']['temperature']
-        self.setpoint_temp = self.modList[0]['measured']['setpoint_temp']
         self.setpoint_mode = self.modList[0]['setpoint']['setpoint_mode']
+        if self.setpoint_mode == 'manual':
+            self.setpoint_temp = self.modList[0]['setpoint']['setpoint_temp']
+        else:
+            self.setpoint_temp = self.modList[0]['measured']['setpoint_temp']
         self.relay_cmd = int(self.modList[0]['therm_relay_cmd'])
         self.devices = { d['_id'] : d for d in self.rawData['devices'] }
         self.modules = dict()


### PR DESCRIPTION
Netatmo, in their infinite wisdom, decided to use two separate properties for the setpoint temperature in the Getthermostatdata endpoint - one for the manual mode, and one for everything else.

The library incorrectly assumes that the setpoint temperature in manual mode should be read from the same property as for other modes. This commit should fix it.