### PR TITLE
Make module loading more robust

### DIFF
--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -63,7 +63,7 @@ class WeatherStationData:
                 return s
         else:
             for id, station in self.stations.items():
-                if station['module_name'] == module:
+                if 'module_name' in station and station['module_name'] == module:
                     return station
         for m in self.modules:
             mod = self.modules[m]
@@ -105,7 +105,7 @@ class WeatherStationData:
         # Define oldest acceptable sensor measure event
         limit = (time.time() - exclude) if exclude else 0
         ds = s['dashboard_data']
-        if ds['time_utc'] > limit :
+        if 'module_name' in s and ds['time_utc'] > limit :
             lastD[s['module_name']] = ds.copy()
             lastD[s['module_name']]['When'] = lastD[s['module_name']].pop("time_utc")
             lastD[s['module_name']]['wifi_status'] = s['wifi_status']


### PR DESCRIPTION
In my environment, homeassistant won't consistently load netatmo without this patch applied
The following exceptions appear in the home assistant log without this patch:

Nov 29 20:19:11 hasspi hass[324]: 2018-11-29 20:19:11 ERROR (MainThread) [homeassistant.components.sensor] Error while setting up platform netatmo
Nov 29 20:19:11 hasspi hass[324]: Traceback (most recent call last):
Nov 29 20:19:11 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity_platform.py", line 128, in _async_setup_platform
Nov 29 20:19:11 hasspi hass[324]:     SLOW_SETUP_MAX_WAIT, loop=hass.loop)
Nov 29 20:19:11 hasspi hass[324]:   File "/usr/lib/python3.5/asyncio/tasks.py", line 400, in wait_for
Nov 29 20:19:11 hasspi hass[324]:     return fut.result()
Nov 29 20:19:11 hasspi hass[324]:   File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
Nov 29 20:19:11 hasspi hass[324]:     raise self._exception
Nov 29 20:19:11 hasspi hass[324]:   File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
Nov 29 20:19:11 hasspi hass[324]:     result = self.fn(*self.args, **self.kwargs)
Nov 29 20:19:11 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/sensor/netatmo.py", line 85, in setup_platform
Nov 29 20:19:11 hasspi hass[324]:     dev.append(NetAtmoSensor(data, module_name, variable))
Nov 29 20:19:11 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/sensor/netatmo.py", line 116, in __init__
Nov 29 20:19:11 hasspi hass[324]:     station_data.moduleByName(module=module_name)['_id']
Nov 29 20:19:11 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/smart_home/WeatherStation.py", line 65, in moduleByName
Nov 29 20:19:11 hasspi hass[324]:     if station['module_name'] == module:
Nov 29 20:19:11 hasspi hass[324]: KeyError: 'module_name'
...
Nov 29 20:19:15 hasspi hass[324]: Traceback (most recent call last):
Nov 29 20:19:15 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/helpers/entity_platform.py", line 128, in _async_setup_platform
Nov 29 20:19:15 hasspi hass[324]:     SLOW_SETUP_MAX_WAIT, loop=hass.loop)
Nov 29 20:19:15 hasspi hass[324]:   File "/usr/lib/python3.5/asyncio/tasks.py", line 400, in wait_for
Nov 29 20:19:15 hasspi hass[324]:     return fut.result()
Nov 29 20:19:15 hasspi hass[324]:   File "/usr/lib/python3.5/asyncio/futures.py", line 293, in result
Nov 29 20:19:15 hasspi hass[324]:     raise self._exception
Nov 29 20:19:15 hasspi hass[324]:   File "/usr/lib/python3.5/concurrent/futures/thread.py", line 55, in run
Nov 29 20:19:15 hasspi hass[324]:     result = self.fn(*self.args, **self.kwargs)
Nov 29 20:19:15 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/sensor/netatmo.py", line 87, in setup_platform
Nov 29 20:19:15 hasspi hass[324]:     for module_name in data.get_module_names():
Nov 29 20:19:15 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/sensor/netatmo.py", line 304, in get_module_names
Nov 29 20:19:15 hasspi hass[324]:     self.update()
Nov 29 20:19:15 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/homeassistant/components/sensor/netatmo.py", line 330, in update
Nov 29 20:19:15 hasspi hass[324]:     self.data = self.station_data.lastData(exclude=3600)
Nov 29 20:19:15 hasspi hass[324]:   File "/srv/homeassistant/lib/python3.5/site-packages/smart_home/WeatherStation.py", line 108, in lastData
Nov 29 20:19:15 hasspi hass[324]:     lastD[s['module_name']] = ds.copy()
Nov 29 20:19:15 hasspi hass[324]: KeyError: 'module_name'