### PR TITLE
Refactor to use IDs rather than names

### DIFF
--- a/fixtures/camera_home_data.json
+++ b/fixtures/camera_home_data.json
@@ -70,6 +70,18 @@
                         "name": "Hall",
                         "use_pin_code": false,
                         "last_setup": 1544828430
+                    },
+                    {
+                        "id": "12:34:56:00:a5:a4",
+                        "type": "NOC",
+                        "status": "on",
+                        "vpn_url": "https://prodvpn-eu-2.netatmo.net/restricted/10.255.248.91/6d278460699e56180d47ab47169efb31/MpEylTU2MDYzNjRVD-LJxUnIndumKzLboeAwMDqTTw,,",
+                        "is_local": true,
+                        "sd_status": "on",
+                        "alim_status": "on",
+                        "name": "Garden",
+                        "last_setup": 1563737661,
+                        "light_mode_status": "auto"
                     }
                 ],
                 "smokedetectors": [],

--- a/fixtures/camera_home_data.json
+++ b/fixtures/camera_home_data.json
@@ -178,6 +178,30 @@
                         "message": "<b>Bewegung</b> erkannt"
                     }
                 ]
+            },
+            {
+                "id": "91763b24c43d3e344f424e8c",
+                "persons": [],
+                "place": {
+                    "city": "Frankfurt",
+                    "country": "DE",
+                    "timezone": "Europe/Berlin"
+                },
+                "cameras": [
+                    {
+                        "id": "12:34:56:00:a5:a5",
+                        "type": "NOC",
+                        "status": "on",
+                        "vpn_url": "https://prodvpn-eu-2.netatmo.net/restricted/10.255.248.91/6d278460699e56180d47ab47169efb31/MpEylTU2MDYzNjRVD-LJxUnIndumKzLboeAwMDqTTz,,",
+                        "is_local": true,
+                        "sd_status": "on",
+                        "alim_status": "on",
+                        "name": "Street",
+                        "last_setup": 1563737561,
+                        "light_mode_status": "auto"
+                    }
+                ],
+                "smokedetectors": []
             }
         ],
         "user": {

--- a/fixtures/home_data_simple.json
+++ b/fixtures/home_data_simple.json
@@ -565,6 +565,18 @@
                     }
                 ],
                 "therm_mode": "schedule"
+            },
+            {
+                "id": "91763b24c43d3e344f424e8c",
+                "altitude": 112,
+                "coordinates": [
+                    52.516263,
+                    13.377726
+                ],
+                "country": "DE",
+                "timezone": "Europe/Berlin",
+                "therm_setpoint_default_duration": 180,
+                "therm_mode": "schedule"
             }
         ],
         "user": {

--- a/pyatmo.py
+++ b/pyatmo.py
@@ -11,12 +11,13 @@ PythonAPI Netatmo REST data access
 import logging
 import time
 
-from smart_home import _BASE_URL, NoDevice, postRequest
+from smart_home import _BASE_URL, postRequest
 from smart_home.Camera import CameraData
 from smart_home.HomeCoach import HomeCoachData
 from smart_home.PublicData import PublicData
 from smart_home.Thermostat import HomeData, HomeStatus
 from smart_home.WeatherStation import WeatherStationData
+from smart_home.Exceptions import NoDevice
 
 LOG = logging.getLogger(__name__)
 

--- a/smart_home/Camera.py
+++ b/smart_home/Camera.py
@@ -113,7 +113,7 @@ class CameraData:
         if not camera and not home:
             return self.default_camera
         elif home and camera:
-            homeId = self.homeByName(home)['id']
+            homeId = self.homeByName(home)["id"]
             if homeId not in self.cameras:
                 return None
             for cam_id in self.cameras[homeId]:
@@ -126,7 +126,7 @@ class CameraData:
                     if self.cameras[homeId][cam_id]["name"] == camera:
                         return self.cameras[homeId][cam_id]
         else:
-            homeId = self.homeByName(home)['id']
+            homeId = self.homeByName(home)["id"]
             return list(self.cameras[homeId].values())[0]
         return None
 
@@ -179,17 +179,13 @@ class CameraData:
             vpn_url = camera_data.get("vpn_url")
             if camera_data.get("is_local"):
                 try:
-                    resp = postRequest(
-                        "{0}/command/ping".format(vpn_url), {}
-                    )
+                    resp = postRequest("{0}/command/ping".format(vpn_url), {})
                     temp_local_url = resp["local_url"]
                 except URLError:
                     return None, None
 
                 try:
-                    resp = postRequest(
-                        "{0}/command/ping".format(temp_local_url), {}
-                    )
+                    resp = postRequest("{0}/command/ping".format(temp_local_url), {})
                     if temp_local_url == resp["local_url"]:
                         local_url = temp_local_url
                 except URLError:

--- a/smart_home/Camera.py
+++ b/smart_home/Camera.py
@@ -121,7 +121,6 @@ class CameraData:
                     return self.cameras[homeId][cam_id]
         elif not home and camera:
             for homeId, cam_ids in self.cameras.items():
-                print(homeId)
                 for cam_id in cam_ids:
                     if self.cameras[homeId][cam_id]["name"] == camera:
                         return self.cameras[homeId][cam_id]

--- a/smart_home/Exceptions.py
+++ b/smart_home/Exceptions.py
@@ -1,0 +1,14 @@
+class NoSchedule(Exception):
+    pass
+
+
+class InvalidHome(Exception):
+    pass
+
+
+class InvalidRoom(Exception):
+    pass
+
+
+class NoDevice(Exception):
+    pass

--- a/smart_home/PublicData.py
+++ b/smart_home/PublicData.py
@@ -1,6 +1,7 @@
 import time
 
-from . import _BASE_URL, NoDevice, postRequest
+from . import _BASE_URL, postRequest
+from .Exceptions import NoDevice
 
 _GETPUBLIC_DATA = _BASE_URL + "api/getpublicdata"
 _LON_NE = 6.221652

--- a/smart_home/Thermostat.py
+++ b/smart_home/Thermostat.py
@@ -100,10 +100,11 @@ class HomeData:
                 if "therm_schedules" in self.homes[key]:
                     return self.homes[key]["id"]
 
-    def getSelectedschedule(self, home=None):
-        if not home:
-            home = self.default_home
-        home_id = self.gethomeId(home=home)
+    def getSelectedschedule(self, home=None, home_id=None):
+        if not home_id:
+            if not home:
+                home = self.default_home
+            home_id = self.gethomeId(home=home)
         self.schedule = self.schedules[home_id]
         for key in self.schedule.keys():
             if "selected" in self.schedule[key].keys():
@@ -143,10 +144,10 @@ class HomeStatus(HomeData):
         self.getAuthToken = authData.accessToken
         self.home_data = HomeData(authData)
 
-        if home_id:
+        if home_id is not None:
             self.home_id = home_id
             LOG.debug("home_id", self.home_id)
-        elif home:
+        elif home is not None:
             self.home_id = self.home_data.gethomeId(home=home)
         else:
             self.home_id = self.home_data.gethomeId(home=self.home_data.default_home)
@@ -247,11 +248,13 @@ class HomeStatus(HomeData):
             setpointmode = room_data["therm_setpoint_mode"]
         return setpointmode
 
-    def getAwaytemp(self, home=None):
-        if not home:
-            home = self.home_data.default_home
-            LOG.debug(self.home_data.default_home)
-        data = self.home_data.getSelectedschedule(home=home)
+    def getAwaytemp(self, home=None, home_id=None):
+        if not home_id:
+            if not home:
+                home = self.home_data.default_home
+                LOG.debug(self.home_data.default_home)
+            home_id = self.home_data.gethomeId(home)
+        data = self.home_data.getSelectedschedule(home_id=home_id)
         return data["away_temp"]
 
     def getHgtemp(self, home=None):

--- a/smart_home/Thermostat.py
+++ b/smart_home/Thermostat.py
@@ -41,13 +41,16 @@ class HomeData:
         self.schedules = {}
         self.zones = {}
         self.setpoint_duration = {}
+        self.default_home = None
+        self.default_home_id = None
         for item in self.rawData:
-            nameHome = item.get("name")
             idHome = item.get("id")
-            if not nameHome:
-                raise NoDevice('No key ["name"] in %s', item.keys())
             if not idHome:
                 raise NoDevice('No key ["id"] in %s', item.keys())
+            nameHome = item.get("name")
+            if not nameHome:
+                nameHome = "Unknown"
+                self.homes[idHome]["name"] = nameHome
             if "modules" in item:
                 if idHome not in self.modules:
                     self.modules[idHome] = {}
@@ -69,7 +72,7 @@ class HomeData:
                     for room in item["rooms"]:
                         self.rooms[idHome][room["id"]] = room
                 if "therm_schedules" in item:
-                    self.default_home = item["name"]
+                    self.default_home = nameHome
                     self.default_home_id = item["id"]
                     for schedule in item["therm_schedules"]:
                         self.schedules[idHome][schedule["id"]] = schedule
@@ -166,9 +169,9 @@ class HomeStatus(HomeData):
         self.thermostats = {}
         self.valves = {}
         self.relays = {}
-        for r in self.rawData["rooms"]:
+        for r in self.rawData.get("rooms", []):
             self.rooms[r["id"]] = r
-        for module in self.rawData["modules"]:
+        for module in self.rawData.get("modules", []):
             if module["type"] == "NATherm1":
                 thermostatId = module["id"]
                 if thermostatId not in self.thermostats:

--- a/smart_home/Thermostat.py
+++ b/smart_home/Thermostat.py
@@ -157,11 +157,7 @@ class HomeStatus(HomeData):
         postParams = {"access_token": self.getAuthToken, "home_id": self.home_id}
 
         resp = postRequest(_GETHOMESTATUS_REQ, postParams)
-        if (
-            "errors" in resp
-            or "body" not in resp
-            or "home" not in resp["body"]
-        ):
+        if "errors" in resp or "body" not in resp or "home" not in resp["body"]:
             raise NoDevice("No device found, errors in response")
             return None
         self.rawData = resp["body"]["home"]

--- a/smart_home/Thermostat.py
+++ b/smart_home/Thermostat.py
@@ -1,6 +1,7 @@
 import logging
 
-from . import _BASE_URL, NoDevice, postRequest
+from . import _BASE_URL, postRequest
+from .Exceptions import NoDevice, NoSchedule, InvalidHome, InvalidRoom
 
 LOG = logging.getLogger(__name__)
 
@@ -10,18 +11,6 @@ _SETTHERMMODE_REQ = _BASE_URL + "api/setthermmode"
 _SETROOMTHERMPOINT_REQ = _BASE_URL + "api/setroomthermpoint"
 _GETROOMMEASURE_REQ = _BASE_URL + "api/getroommeasure"
 _SWITCHHOMESCHEDULE_REQ = _BASE_URL + "api/switchhomeschedule"
-
-
-class NoSchedule(Exception):
-    pass
-
-
-class InvalidHome(Exception):
-    pass
-
-
-class InvalidRoom(Exception):
-    pass
 
 
 class HomeData:
@@ -100,6 +89,7 @@ class HomeData:
         for key, value in self.homes.items():
             if value["name"] == home:
                 return self.homes[key]
+        raise InvalidHome("Invalid Home %s" % home)
 
     def gethomeId(self, home=None):
         if not home:

--- a/smart_home/Thermostat.py
+++ b/smart_home/Thermostat.py
@@ -102,6 +102,16 @@ class HomeData:
                 LOG.debug(self.default_home)
                 if "therm_schedules" in self.homes[key]:
                     return self.homes[key]["id"]
+    
+    def getHomeName(self, home_id=None):
+        if home_id is None:
+            home_id = self.default_home_id
+        for key, value in self.homes.items():
+            if value["id"] == home_id:
+                LOG.debug(self.homes[key]["id"])
+                LOG.debug(self.default_home)
+                if "therm_schedules" in self.homes[key]:
+                    return self.homes[key]["name"]
 
     def getSelectedschedule(self, home=None, home_id=None):
         if not home_id:
@@ -256,10 +266,13 @@ class HomeStatus(HomeData):
         data = self.home_data.getSelectedschedule(home_id=home_id)
         return data["away_temp"]
 
-    def getHgtemp(self, home=None):
-        if not home:
-            home = self.home_data.default_home
-        data = self.home_data.getSelectedschedule(home=home)
+    def getHgtemp(self, home=None, home_id=None):
+        if not home_id:
+            if not home:
+                home = self.home_data.default_home
+                LOG.debug(self.home_data.default_home)
+            home_id = self.home_data.gethomeId(home)
+        data = self.home_data.getSelectedschedule(home_id=home_id)
         return data["hg_temp"]
 
     def measuredTemperature(self, rid=None):
@@ -287,9 +300,10 @@ class HomeStatus(HomeData):
             boiler_status = relay_status["boiler_status"]
         return boiler_status
 
-    def thermostatType(self, home, rid):
+    def thermostatType(self, home, rid, home_id=None):
         module_id = None
-        home_id = self.home_data.gethomeId(home=home)
+        if home_id is None:
+            home_id = self.home_data.gethomeId(home=home)
         for key in self.home_data.rooms[home_id]:
             if key == rid:
                 for module_id in self.home_data.rooms[home_id][rid]["module_ids"]:

--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -62,8 +62,8 @@ class WeatherStationData:
                 res.add(station["module_name"])
         return list(res)
 
-    def stationByName(self, station=None):
-        if not station:
+    def stationByName(self, station=None, station_id=None):
+        if not station and not station_id:
             station = self.default_station
         for i, s in self.stations.items():
             if s["station_name"] == station:

--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -62,8 +62,8 @@ class WeatherStationData:
                 res.add(station["module_name"])
         return list(res)
 
-    def stationByName(self, station=None, station_id=None):
-        if not station and not station_id:
+    def stationByName(self, station=None):
+        if not station:
             station = self.default_station
         for i, s in self.stations.items():
             if s["station_name"] == station:

--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -1,7 +1,8 @@
 import logging
 import time
 
-from . import _BASE_URL, NoDevice, postRequest, todayStamps
+from . import _BASE_URL, postRequest, todayStamps
+from .Exceptions import NoDevice
 
 LOG = logging.getLogger(__name__)
 

--- a/smart_home/WeatherStation.py
+++ b/smart_home/WeatherStation.py
@@ -45,16 +45,19 @@ class WeatherStationData:
                 self.modules[m["_id"]]["main_device"] = item["_id"]
         self.default_station = list(self.stations.values())[0]["station_name"]
 
-    def modulesNamesList(self, station=None):
-        if station:
-            res = set()
-            s = self.stationByName(station)
-            if s is not None:
-                res.add(s["module_name"])
-                for m in s["modules"]:
-                    res.add(m["module_name"])
+    def modulesNamesList(self, station=None, station_id=None):
+        res = set()
+        station_data = None
+        if station_id is not None:
+            station_data = self.stationById(station_id)
+        elif station is not None:
+            station_data = self.stationByName(station)
+        if station_data is not None:
+            res.add(station_data["module_name"])
+            for m in station_data["modules"]:
+                res.add(m["module_name"])
         else:
-            res = set([m["module_name"] for m in self.modules.values()])
+            res.update([m["module_name"] for m in self.modules.values()])
             for id, station in self.stations.items():
                 res.add(station["module_name"])
         return list(res)

--- a/smart_home/__init__.py
+++ b/smart_home/__init__.py
@@ -9,10 +9,6 @@ LOG = logging.getLogger(__name__)
 _BASE_URL = "https://api.netatmo.com/"
 
 
-class NoDevice(Exception):
-    pass
-
-
 # Utilities routines
 
 

--- a/tests/test_smart_home_camera.py
+++ b/tests/test_smart_home_camera.py
@@ -49,7 +49,13 @@ def test_CameraData_homeByName(cameraHomeData, name, expected):
 
 
 @pytest.mark.parametrize(
-    "cid, expected", [("12:34:56:00:f1:62", "Hall"), ("None", None), (None, None)]
+    "cid, expected",
+    [
+        ("12:34:56:00:f1:62", "Hall"),
+        ("12:34:56:00:a5:a4", "Garden"),
+        ("None", None),
+        (None, None),
+    ],
 )
 def test_CameraData_cameraById(cameraHomeData, cid, expected):
     camera = cameraHomeData.cameraById(cid)
@@ -68,6 +74,7 @@ def test_CameraData_cameraById(cameraHomeData, cid, expected):
         ("Hall", "MYHOME", "12:34:56:00:f1:62"),
         (None, "MYHOME", "12:34:56:00:f1:62"),
         ("", "MYHOME", "12:34:56:00:f1:62"),
+        ("Garden", "MYHOME", "12:34:56:00:a5:a4"),
         pytest.param(
             "InvalidName",
             None,
@@ -95,6 +102,7 @@ def test_CameraData_cameraByName(cameraHomeData, name, home, expected):
         (None, "MYHOME", None, "NACamera"),
         (None, "MYHOME", "12:34:56:00:f1:62", "NACamera"),
         (None, None, "12:34:56:00:f1:62", "NACamera"),
+        ("Garden", None, None, "NOC"),
         ("InvalidName", None, None, None),
         pytest.param(
             None,

--- a/tests/test_smart_home_camera.py
+++ b/tests/test_smart_home_camera.py
@@ -10,6 +10,9 @@ from .conftest import does_not_raise
 import smart_home.Camera
 
 
+INVALID_NAME = "InvalidName"
+
+
 def test_CameraData(cameraHomeData):
     assert cameraHomeData.default_home == "MYHOME"
     assert cameraHomeData.default_camera["id"] == "12:34:56:00:f1:62"
@@ -38,7 +41,7 @@ def test_CameraData_homeById(cameraHomeData, hid, expected):
         (None, "91763b24c43d3e344f424e8b"),
         ("", "91763b24c43d3e344f424e8b"),
         pytest.param(
-            "InvalidName",
+            INVALID_NAME,
             None,
             marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
         ),
@@ -75,22 +78,23 @@ def test_CameraData_cameraById(cameraHomeData, cid, expected):
         (None, "MYHOME", "12:34:56:00:f1:62"),
         ("", "MYHOME", "12:34:56:00:f1:62"),
         ("Garden", "MYHOME", "12:34:56:00:a5:a4"),
-        pytest.param(
-            "InvalidName",
-            None,
-            None,
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
-        ),
-        pytest.param(
-            None,
-            "InvalidName",
-            None,
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
-        ),
+        pytest.param(INVALID_NAME, None, None),
+        pytest.param(None, INVALID_NAME, None),
     ],
 )
 def test_CameraData_cameraByName(cameraHomeData, name, home, expected):
-    assert cameraHomeData.cameraByName(name, home)["id"] == expected
+    if home == INVALID_NAME or name == INVALID_NAME:
+        assert cameraHomeData.cameraByName(name, home) is None
+    else:
+        assert cameraHomeData.cameraByName(name, home)["id"] == expected
+
+
+def test_CameraData_moduleById(cameraHomeData):
+    assert cameraHomeData.moduleById("00:00:00:00:00:00") is None
+
+
+def test_CameraData_moduleByName(cameraHomeData):
+    assert cameraHomeData.moduleByName() is None
 
 
 @pytest.mark.parametrize(
@@ -103,10 +107,10 @@ def test_CameraData_cameraByName(cameraHomeData, name, home, expected):
         (None, "MYHOME", "12:34:56:00:f1:62", "NACamera"),
         (None, None, "12:34:56:00:f1:62", "NACamera"),
         ("Garden", None, None, "NOC"),
-        ("InvalidName", None, None, None),
+        (INVALID_NAME, None, None, None),
         pytest.param(
             None,
-            "InvalidName",
+            INVALID_NAME,
             None,
             "NACamera",
             marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),

--- a/tests/test_smart_home_camera.py
+++ b/tests/test_smart_home_camera.py
@@ -23,15 +23,15 @@ def test_CameraData(cameraHomeData):
     "hid, expected",
     [
         ("91763b24c43d3e344f424e8b", "MYHOME"),
-        pytest.param(
-            None,
-            None,
-            marks=pytest.mark.xfail(reason="Invalid home id not handled yet"),
-        ),
+        (INVALID_NAME, "MYHOME"),
+        pytest.param(None, None),
     ],
 )
 def test_CameraData_homeById(cameraHomeData, hid, expected):
-    assert cameraHomeData.homeById(hid)["name"] == expected
+    if hid is None or hid == INVALID_NAME:
+        assert cameraHomeData.homeById(hid) is None
+    else:
+        assert cameraHomeData.homeById(hid)["name"] == expected
 
 
 @pytest.mark.parametrize(
@@ -40,15 +40,15 @@ def test_CameraData_homeById(cameraHomeData, hid, expected):
         ("MYHOME", "91763b24c43d3e344f424e8b"),
         (None, "91763b24c43d3e344f424e8b"),
         ("", "91763b24c43d3e344f424e8b"),
-        pytest.param(
-            INVALID_NAME,
-            None,
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
-        ),
+        pytest.param(INVALID_NAME, None),
     ],
 )
 def test_CameraData_homeByName(cameraHomeData, name, expected):
-    assert cameraHomeData.homeByName(name)["id"] == expected
+    if name == INVALID_NAME:
+        with pytest.raises(smart_home.Exceptions.InvalidHome):
+            assert cameraHomeData.homeByName(name)
+    else:
+        assert cameraHomeData.homeByName(name)["id"] == expected
 
 
 @pytest.mark.parametrize(
@@ -108,13 +108,7 @@ def test_CameraData_moduleByName(cameraHomeData):
         (None, None, "12:34:56:00:f1:62", "NACamera"),
         ("Garden", None, None, "NOC"),
         (INVALID_NAME, None, None, None),
-        pytest.param(
-            None,
-            INVALID_NAME,
-            None,
-            "NACamera",
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
-        ),
+        pytest.param(None, INVALID_NAME, None, None),
     ],
 )
 def test_CameraData_cameraType(cameraHomeData, camera, home, cid, expected):
@@ -163,14 +157,18 @@ def test_CameraData_cameraUrls_disconnected(auth, requests_mock):
         (None, ["Richard Doe"]),
         ("MYHOME", ["Richard Doe"]),
         pytest.param(
-            "InvalidHome",
+            INVALID_NAME,
             None,
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
+            # marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
         ),
     ],
 )
 def test_CameraData_personsAtHome(cameraHomeData, home, expected):
-    assert cameraHomeData.personsAtHome(home) == expected
+    if home == INVALID_NAME:
+        with pytest.raises(smart_home.Exceptions.InvalidHome):
+            assert cameraHomeData.personsAtHome(home)
+    else:
+        assert cameraHomeData.personsAtHome(home) == expected
 
 
 @freeze_time("2019-06-16")
@@ -210,13 +208,7 @@ def test_CameraData_knownPersonsNames(cameraHomeData):
         (None, None, None, True),
         (None, None, 5, False),
         (None, "InvalidCamera", None, False),
-        pytest.param(
-            "InvalidHome",
-            None,
-            None,
-            True,
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
-        ),
+        ("InvalidHome", None, None, False),
     ],
 )
 def test_CameraData_someoneKnownSeen(cameraHomeData, home, camera, exclude, expected):
@@ -229,14 +221,8 @@ def test_CameraData_someoneKnownSeen(cameraHomeData, home, camera, exclude, expe
     [
         (None, None, None, False),
         (None, None, 100, False),
-        (None, "InvalidCamera", None, False),
-        pytest.param(
-            "InvalidHome",
-            None,
-            None,
-            False,
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
-        ),
+        (None, INVALID_NAME, None, False),
+        (INVALID_NAME, None, None, False),
     ],
 )
 def test_CameraData_someoneUnknownSeen(cameraHomeData, home, camera, exclude, expected):
@@ -250,14 +236,8 @@ def test_CameraData_someoneUnknownSeen(cameraHomeData, home, camera, exclude, ex
         (None, None, None, False),
         (None, None, 140000, True),
         (None, None, 130000, False),
-        (None, "InvalidCamera", None, False),
-        pytest.param(
-            "InvalidHome",
-            None,
-            None,
-            False,
-            marks=pytest.mark.xfail(reason="Invalid home name not handled yet"),
-        ),
+        (None, INVALID_NAME, None, False),
+        (INVALID_NAME, None, None, False),
     ],
 )
 def test_CameraData_motionDetected(cameraHomeData, home, camera, exclude, expected):

--- a/tests/test_smart_home_homecoach.py
+++ b/tests/test_smart_home_homecoach.py
@@ -22,4 +22,3 @@ def test_HomeCoachData(homeCoachData):
 )
 def test_HomeCoachData_modulesNamesList(homeCoachData, station, expected):
     assert sorted(homeCoachData.modulesNamesList(station)) == expected
-

--- a/tests/test_smart_home_thermostat.py
+++ b/tests/test_smart_home_thermostat.py
@@ -124,7 +124,7 @@ def test_HomeData_getHomeName(homeData):
 def test_HomeData_getSelectedschedule(homeData):
     assert homeData.getSelectedschedule()["name"] == "Default"
     assert homeData.getSelectedschedule("MYHOME")["name"] == "Default"
-    with pytest.raises(smart_home.Thermostat.InvalidHome): 
+    with pytest.raises(smart_home.Thermostat.InvalidHome):
         assert homeData.getSelectedschedule("Unknown")
 
 

--- a/tests/test_smart_home_thermostat.py
+++ b/tests/test_smart_home_thermostat.py
@@ -89,24 +89,30 @@ def test_HomeData_no_home_name(auth, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    # with pytest.raises(smart_home.PublicData.NoDevice):
     homeData = smart_home.Thermostat.HomeData(auth)
     home_id = "91763b24c43d3e344f424e8b"
-    print(homeData.homeById(home_id))
     assert homeData.homeById(home_id)["name"] == "Unknown"
 
 
 def test_HomeData_homeById(homeData):
     home_id = "91763b24c43d3e344f424e8b"
     assert homeData.homeById(home_id)["name"] == "MYHOME"
+    home_id = "91763b24c43d3e344f424e8c"
+    assert homeData.homeById(home_id)["name"] == "Unknown"
 
 
 def test_HomeData_homeByName(homeData):
     assert homeData.homeByName()["name"] == "MYHOME"
+    assert homeData.homeByName()["id"] == "91763b24c43d3e344f424e8b"
 
 
 def test_HomeData_gethomeId(homeData):
     assert homeData.gethomeId() == "91763b24c43d3e344f424e8b"
+    assert homeData.gethomeId("MYHOME") == "91763b24c43d3e344f424e8b"
+
+
+def test_HomeData_getHomeName(homeData):
+    assert homeData.getHomeName() == "MYHOME"
 
 
 def test_HomeData_getSelectedschedule(homeData):

--- a/tests/test_smart_home_thermostat.py
+++ b/tests/test_smart_home_thermostat.py
@@ -109,14 +109,23 @@ def test_HomeData_homeByName(homeData):
 def test_HomeData_gethomeId(homeData):
     assert homeData.gethomeId() == "91763b24c43d3e344f424e8b"
     assert homeData.gethomeId("MYHOME") == "91763b24c43d3e344f424e8b"
+    with pytest.raises(smart_home.Thermostat.InvalidHome):
+        assert homeData.gethomeId("InvalidName")
 
 
 def test_HomeData_getHomeName(homeData):
     assert homeData.getHomeName() == "MYHOME"
+    home_id = "91763b24c43d3e344f424e8b"
+    assert homeData.getHomeName(home_id) == "MYHOME"
+    home_id = "91763b24c43d3e344f424e8c"
+    assert homeData.getHomeName(home_id) == "Unknown"
 
 
 def test_HomeData_getSelectedschedule(homeData):
     assert homeData.getSelectedschedule()["name"] == "Default"
+    assert homeData.getSelectedschedule("MYHOME")["name"] == "Default"
+    with pytest.raises(smart_home.Thermostat.InvalidHome): 
+        assert homeData.getSelectedschedule("Unknown")
 
 
 @pytest.mark.parametrize(
@@ -227,6 +236,8 @@ def test_HomeStatus_roomById(homeStatus):
         "therm_setpoint_end_time": 0,
     }
     assert homeStatus.roomById("2746182631") == expexted
+    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+        assert homeStatus.roomById("0000000000")
 
 
 def test_HomeStatus_thermostatById(homeStatus):
@@ -244,6 +255,8 @@ def test_HomeStatus_thermostatById(homeStatus):
         "battery_state": "high",
     }
     assert homeStatus.thermostatById("12:34:56:00:01:ae") == expexted
+    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+        assert homeStatus.thermostatById("00:00:00:00:00:00")
 
 
 def test_HomeStatus_relayById(homeStatus):
@@ -255,6 +268,8 @@ def test_HomeStatus_relayById(homeStatus):
         "wifi_strength": 42,
     }
     assert homeStatus.relayById("12:34:56:00:fa:d0") == expexted
+    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+        assert homeStatus.relayById("00:00:00:00:00:00")
 
 
 def test_HomeStatus_valveById(homeStatus):
@@ -269,26 +284,45 @@ def test_HomeStatus_valveById(homeStatus):
         "battery_state": "full",
     }
     assert homeStatus.valveById("12:34:56:03:a5:54") == expexted
+    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+        assert homeStatus.valveById("00:00:00:00:00:00")
 
 
 def test_HomeStatus_setPoint(homeStatus):
+    assert homeStatus.setPoint() == 12
     assert homeStatus.setPoint("2746182631") == 12
+    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+        assert homeStatus.setPoint("0000000000")
 
 
 def test_HomeStatus_setPointmode(homeStatus):
+    assert homeStatus.setPointmode() == "away"
     assert homeStatus.setPointmode("2746182631") == "away"
+    assert homeStatus.setPointmode("0000000000") is None
 
 
 def test_HomeStatus_getAwaytemp(homeStatus):
     assert homeStatus.getAwaytemp() == 14
+    assert homeStatus.getAwaytemp("MYHOME") == 14
+    assert homeStatus.getAwaytemp("InvalidName") is None
+    assert homeStatus.getAwaytemp(home_id="91763b24c43d3e344f424e8b") == 14
+    assert homeStatus.getAwaytemp(home_id="00000000000000000000000") is None
 
 
 def test_HomeStatus_getHgtemp(homeStatus):
     assert homeStatus.getHgtemp() == 7
+    assert homeStatus.getHgtemp("MYHOME") == 7
+    with pytest.raises(smart_home.Thermostat.InvalidHome):
+        assert homeStatus.getHgtemp("InvalidHome")
+    assert homeStatus.getHgtemp(home_id="91763b24c43d3e344f424e8b") == 7
+    assert homeStatus.getHgtemp(home_id="00000000000000000000000") is None
 
 
 def test_HomeStatus_measuredTemperature(homeStatus):
     assert homeStatus.measuredTemperature() == 19.8
+    assert homeStatus.measuredTemperature("2746182631") == 19.8
+    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+        assert homeStatus.measuredTemperature("0000000000")
 
 
 def test_HomeStatus_boilerStatus(homeStatus):
@@ -298,6 +332,9 @@ def test_HomeStatus_boilerStatus(homeStatus):
 def test_HomeStatus_thermostatType(homeStatus):
     assert homeStatus.thermostatType("MYHOME", "2746182631") == "NATherm1"
     assert homeStatus.thermostatType("MYHOME", "2833524037") == "NRV"
+    with pytest.raises(smart_home.Thermostat.InvalidHome):
+        assert homeStatus.thermostatType("InvalidHome", "2833524037")
+    assert homeStatus.thermostatType("MYHOME", "0000000000") is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_smart_home_thermostat.py
+++ b/tests/test_smart_home_thermostat.py
@@ -11,9 +11,10 @@ import smart_home.Thermostat
 
 def test_HomeData(homeData):
     assert homeData.default_home == "MYHOME"
-    assert len(homeData.rooms[homeData.default_home]) == 4
+    assert homeData.default_home_id == "91763b24c43d3e344f424e8b"
+    assert len(homeData.rooms[homeData.default_home_id]) == 4
 
-    assert len(homeData.modules[homeData.default_home]) == 5
+    assert len(homeData.modules[homeData.default_home_id]) == 5
 
     expected = {
         "12:34:56:00:fa:d0": {
@@ -59,7 +60,7 @@ def test_HomeData(homeData):
             "room_id": "3688132631",
         },
     }
-    assert homeData.modules[homeData.default_home] == expected
+    assert homeData.modules[homeData.default_home_id] == expected
 
 
 def test_HomeData_no_data(auth, requests_mock):

--- a/tests/test_smart_home_thermostat.py
+++ b/tests/test_smart_home_thermostat.py
@@ -7,6 +7,7 @@ import pytest
 from .conftest import does_not_raise
 
 import smart_home.Thermostat
+import smart_home.Exceptions
 
 
 def test_HomeData(homeData):
@@ -124,22 +125,22 @@ def test_HomeData_getHomeName(homeData):
 def test_HomeData_getSelectedschedule(homeData):
     assert homeData.getSelectedschedule()["name"] == "Default"
     assert homeData.getSelectedschedule("MYHOME")["name"] == "Default"
-    with pytest.raises(smart_home.Thermostat.InvalidHome):
+    with pytest.raises(smart_home.Exceptions.InvalidHome):
         assert homeData.getSelectedschedule("Unknown")
 
 
 @pytest.mark.parametrize(
     "t_home, t_sched_id, t_sched, expected",
     [
-        (None, None, None, pytest.raises(smart_home.Thermostat.NoSchedule)),
+        (None, None, None, pytest.raises(smart_home.Exceptions.NoSchedule)),
         (None, None, "Default", does_not_raise()),
         (None, "591b54a2764ff4d50d8b5795", None, does_not_raise()),
-        (None, None, "Summer", pytest.raises(smart_home.Thermostat.NoSchedule)),
+        (None, None, "Summer", pytest.raises(smart_home.Exceptions.NoSchedule)),
         (
             None,
             "123456789abcdefg12345678",
             None,
-            pytest.raises(smart_home.Thermostat.NoSchedule),
+            pytest.raises(smart_home.Exceptions.NoSchedule),
         ),
     ],
 )
@@ -221,7 +222,7 @@ def test_HomeStatus_error(auth, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    with pytest.raises(smart_home.Thermostat.NoDevice):
+    with pytest.raises(smart_home.Exceptions.NoDevice):
         assert smart_home.Thermostat.HomeStatus(auth)
 
 
@@ -236,7 +237,7 @@ def test_HomeStatus_roomById(homeStatus):
         "therm_setpoint_end_time": 0,
     }
     assert homeStatus.roomById("2746182631") == expexted
-    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+    with pytest.raises(smart_home.Exceptions.InvalidRoom):
         assert homeStatus.roomById("0000000000")
 
 
@@ -255,7 +256,7 @@ def test_HomeStatus_thermostatById(homeStatus):
         "battery_state": "high",
     }
     assert homeStatus.thermostatById("12:34:56:00:01:ae") == expexted
-    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+    with pytest.raises(smart_home.Exceptions.InvalidRoom):
         assert homeStatus.thermostatById("00:00:00:00:00:00")
 
 
@@ -268,7 +269,7 @@ def test_HomeStatus_relayById(homeStatus):
         "wifi_strength": 42,
     }
     assert homeStatus.relayById("12:34:56:00:fa:d0") == expexted
-    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+    with pytest.raises(smart_home.Exceptions.InvalidRoom):
         assert homeStatus.relayById("00:00:00:00:00:00")
 
 
@@ -284,14 +285,14 @@ def test_HomeStatus_valveById(homeStatus):
         "battery_state": "full",
     }
     assert homeStatus.valveById("12:34:56:03:a5:54") == expexted
-    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+    with pytest.raises(smart_home.Exceptions.InvalidRoom):
         assert homeStatus.valveById("00:00:00:00:00:00")
 
 
 def test_HomeStatus_setPoint(homeStatus):
     assert homeStatus.setPoint() == 12
     assert homeStatus.setPoint("2746182631") == 12
-    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+    with pytest.raises(smart_home.Exceptions.InvalidRoom):
         assert homeStatus.setPoint("0000000000")
 
 
@@ -312,7 +313,7 @@ def test_HomeStatus_getAwaytemp(homeStatus):
 def test_HomeStatus_getHgtemp(homeStatus):
     assert homeStatus.getHgtemp() == 7
     assert homeStatus.getHgtemp("MYHOME") == 7
-    with pytest.raises(smart_home.Thermostat.InvalidHome):
+    with pytest.raises(smart_home.Exceptions.InvalidHome):
         assert homeStatus.getHgtemp("InvalidHome")
     assert homeStatus.getHgtemp(home_id="91763b24c43d3e344f424e8b") == 7
     assert homeStatus.getHgtemp(home_id="00000000000000000000000") is None
@@ -321,7 +322,7 @@ def test_HomeStatus_getHgtemp(homeStatus):
 def test_HomeStatus_measuredTemperature(homeStatus):
     assert homeStatus.measuredTemperature() == 19.8
     assert homeStatus.measuredTemperature("2746182631") == 19.8
-    with pytest.raises(smart_home.Thermostat.InvalidRoom):
+    with pytest.raises(smart_home.Exceptions.InvalidRoom):
         assert homeStatus.measuredTemperature("0000000000")
 
 
@@ -332,7 +333,7 @@ def test_HomeStatus_boilerStatus(homeStatus):
 def test_HomeStatus_thermostatType(homeStatus):
     assert homeStatus.thermostatType("MYHOME", "2746182631") == "NATherm1"
     assert homeStatus.thermostatType("MYHOME", "2833524037") == "NRV"
-    with pytest.raises(smart_home.Thermostat.InvalidHome):
+    with pytest.raises(smart_home.Exceptions.InvalidHome):
         assert homeStatus.thermostatType("InvalidHome", "2833524037")
     assert homeStatus.thermostatType("MYHOME", "0000000000") is None
 

--- a/tests/test_smart_home_thermostat.py
+++ b/tests/test_smart_home_thermostat.py
@@ -89,8 +89,11 @@ def test_HomeData_no_home_name(auth, requests_mock):
         json=json_fixture,
         headers={"content-type": "application/json"},
     )
-    with pytest.raises(smart_home.PublicData.NoDevice):
-        assert smart_home.Thermostat.HomeData(auth)
+    # with pytest.raises(smart_home.PublicData.NoDevice):
+    homeData = smart_home.Thermostat.HomeData(auth)
+    home_id = "91763b24c43d3e344f424e8b"
+    print(homeData.homeById(home_id))
+    assert homeData.homeById(home_id)["name"] == "Unknown"
 
 
 def test_HomeData_homeById(homeData):


### PR DESCRIPTION
The use of names causes issues when multiple homes (with different IDs) have the same name. Further it can happen that homes don't have a name, which also causes issues.

Therefore this refactoring introduces the use of IDs as unique identifier.

This PR is required to implement https://github.com/home-assistant/home-assistant/pull/25457.
It should solve https://github.com/home-assistant/home-assistant/issues/23075, https://github.com/home-assistant/home-assistant/issues/25387, https://github.com/home-assistant/home-assistant/issues/23558, https://github.com/home-assistant/home-assistant/issues/22066