### PR TITLE
Fix camera detection

### DIFF
--- a/smart_home/Camera.py
+++ b/smart_home/Camera.py
@@ -52,7 +52,9 @@ class CameraData:
                 nameHome = "Unknown"
                 self.homes[homeId]["name"] = nameHome
             if not homeId:
-                raise NoDevice('No key ["id"] in %s' % item.keys())
+                print("----------------SKIPPED-----------------")
+                print(item)
+                continue
             if homeId not in self.cameras:
                 self.cameras[homeId] = {}
             if homeId not in self.types:

--- a/smart_home/Camera.py
+++ b/smart_home/Camera.py
@@ -52,8 +52,6 @@ class CameraData:
                 nameHome = "Unknown"
                 self.homes[homeId]["name"] = nameHome
             if not homeId:
-                print("----------------SKIPPED-----------------")
-                print(item)
                 continue
             if homeId not in self.cameras:
                 self.cameras[homeId] = {}

--- a/smart_home/Camera.py
+++ b/smart_home/Camera.py
@@ -52,6 +52,7 @@ class CameraData:
                 nameHome = "Unknown"
                 self.homes[homeId]["name"] = nameHome
             if not homeId:
+                LOG.error('No key ["id"] in %s', item.keys())
                 continue
             if homeId not in self.cameras:
                 self.cameras[homeId] = {}


### PR DESCRIPTION
Hi, I have a HomeCoach, a Camera and a Thermostat from netatmo.
In the modified loop (` for item in self.rawData:`) I receive an item without `id`, I don't know what it is, but if it raises there the `NoDevice` it skips the Camera and it is not discovered.

I have also issues with the thermostat, that it is not recognized anymore, but I still don't know where is the issue.