### PR TITLE
Fix webhook registration

### DIFF
--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -447,6 +447,8 @@ class CameraData:
             "home_id": home_id,
             "event_id": event["id"],
         }
+
+        eventList = []
         try:
             resp = self.authData.post_request(
                 url=_GETEVENTSUNTIL_REQ, params=postParams
@@ -457,7 +459,6 @@ class CameraData:
         except KeyError:
             LOG.debug("eventList response: %s", resp)
             LOG.debug("eventList body: %s", resp["body"])
-            eventList = []
 
         for e in eventList:
             if e["type"] == "outdoor":

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -2,6 +2,8 @@ import imghdr
 import time
 from typing import Dict, Tuple
 
+from requests.exceptions import ReadTimeout
+
 from .exceptions import ApiError, InvalidHome, NoDevice
 from .helpers import _BASE_URL, LOG
 
@@ -272,7 +274,8 @@ class CameraData:
                         return None
                     try:
                         resp = self.authData.post_request(url=f"{url}/command/ping")
-                    except ApiError:
+                    except (ApiError, ReadTimeout):
+                        LOG.debug("Timeout validation the camera url %s", url)
                         return None
                     else:
                         return resp.get("local_url")


### PR DESCRIPTION
If token was passed the scope was incorrectly set to the default scope. This is fixed now by evaluating the actual scope in the token and set accordingly.

Further the retry after the token refresh is now delayed to prevent timeout errors. (I am aware that `sleep(1)` is not pretty but I couldn't think of an easier solution)