### PR TITLE
Add set state call for camera devices

### DIFF
--- a/fixtures/camera_set_state_error.json
+++ b/fixtures/camera_set_state_error.json
@@ -1,0 +1,6 @@
+{
+    "error": {
+        "code": 21,
+        "message": "Invalid device_id, 12:34:56:00:f1:ff"
+    }
+}

--- a/fixtures/camera_set_state_error_already_on.json
+++ b/fixtures/camera_set_state_error_already_on.json
@@ -1,0 +1,17 @@
+{
+    "status": "ok",
+    "time_server": 1582932399,
+    "body": {
+        "home": {
+            "id": "91763b24c43d3e344f424e8b"
+        },
+        "errors": [
+            {
+                "code": 23,
+                "message": "Already on",
+                "id": "12:34:56:00:f1:62",
+                "command": "command/changestatus"
+            }
+        ]
+    }
+}

--- a/fixtures/camera_set_state_error_wrong_parameter.json
+++ b/fixtures/camera_set_state_error_wrong_parameter.json
@@ -1,0 +1,6 @@
+{
+    "error": {
+        "code": 21,
+        "message": "cannot set property floodlight for module 70:ee:50:1f:f1:62"
+    }
+}

--- a/fixtures/camera_set_state_error_wrong_parameter.json
+++ b/fixtures/camera_set_state_error_wrong_parameter.json
@@ -1,6 +1,6 @@
 {
     "error": {
         "code": 21,
-        "message": "cannot set property floodlight for module 70:ee:50:1f:f1:62"
+        "message": "cannot set property floodlight for module 12:34:56:00:f1:62"
     }
 }

--- a/fixtures/camera_set_state_ok.json
+++ b/fixtures/camera_set_state_ok.json
@@ -1,0 +1,4 @@
+{
+    "status": "ok",
+    "time_server": 1582932411
+}

--- a/fixtures/weatherstation_data_unreachable_station.json
+++ b/fixtures/weatherstation_data_unreachable_station.json
@@ -209,8 +209,8 @@
                     "country": "NO",
                     "timezone": "Europe/Oslo",
                     "location": [
-                        59.903781,
-                        10.683728
+                        59.895000,
+                        10.620000
                     ]
                 },
                 "modules": [

--- a/fixtures/weatherstation_data_unreachable_station.json
+++ b/fixtures/weatherstation_data_unreachable_station.json
@@ -1,0 +1,271 @@
+{
+    "body": {
+        "devices": [
+            {
+                "_id": "12:34:56:37:11:ca",
+                "cipher_id": "enc:16:zjiZF/q8jTScXVdDa/kvhUAIUPGeYszaD1ClEf8byAJkRjxc5oth7cAocrMUIApX",
+                "date_setup": 1544558432,
+                "last_setup": 1544558432,
+                "type": "NAMain",
+                "last_status_store": 1559413181,
+                "module_name": "NetatmoIndoor",
+                "firmware": 137,
+                "last_upgrade": 1544558433,
+                "wifi_status": 45,
+                "reachable": true,
+                "co2_calibrating": false,
+                "station_name": "MyStation",
+                "data_type": [
+                    "Temperature",
+                    "CO2",
+                    "Humidity",
+                    "Noise",
+                    "Pressure"
+                ],
+                "place": {
+                    "altitude": 664,
+                    "city": "Frankfurt",
+                    "country": "DE",
+                    "timezone": "Europe/Berlin",
+                    "location": [
+                        52.516263,
+                        13.377726
+                    ]
+                },
+                "dashboard_data": {
+                    "time_utc": 1559413171,
+                    "Temperature": 24.6,
+                    "CO2": 749,
+                    "Humidity": 36,
+                    "Noise": 37,
+                    "Pressure": 1017.3,
+                    "AbsolutePressure": 939.7,
+                    "min_temp": 23.4,
+                    "max_temp": 25.6,
+                    "date_min_temp": 1559371924,
+                    "date_max_temp": 1559411964,
+                    "temp_trend": "stable",
+                    "pressure_trend": "down"
+                },
+                "modules": [
+                    {
+                        "_id": "12:34:56:36:fc:de",
+                        "type": "NAModule1",
+                        "module_name": "NetatmoOutdoor",
+                        "data_type": [
+                            "Temperature",
+                            "Humidity"
+                        ],
+                        "last_setup": 1544558433,
+                        "reachable": true,
+                        "dashboard_data": {
+                            "time_utc": 1559413157,
+                            "Temperature": 28.6,
+                            "Humidity": 24,
+                            "min_temp": 16.9,
+                            "max_temp": 30.3,
+                            "date_min_temp": 1559365579,
+                            "date_max_temp": 1559404698,
+                            "temp_trend": "down"
+                        },
+                        "firmware": 46,
+                        "last_message": 1559413177,
+                        "last_seen": 1559413157,
+                        "rf_status": 65,
+                        "battery_vp": 5738,
+                        "battery_percent": 87
+                    },
+                    {
+                        "_id": "12:34:56:07:bb:3e",
+                        "type": "NAModule4",
+                        "module_name": "Kitchen",
+                        "data_type": [
+                            "Temperature",
+                            "CO2",
+                            "Humidity"
+                        ],
+                        "last_setup": 1548956696,
+                        "reachable": true,
+                        "dashboard_data": {
+                            "time_utc": 1559413125,
+                            "Temperature": 28,
+                            "CO2": 503,
+                            "Humidity": 26,
+                            "min_temp": 25,
+                            "max_temp": 28,
+                            "date_min_temp": 1559371577,
+                            "date_max_temp": 1559412561,
+                            "temp_trend": "up"
+                        },
+                        "firmware": 44,
+                        "last_message": 1559413177,
+                        "last_seen": 1559413177,
+                        "rf_status": 73,
+                        "battery_vp": 5687,
+                        "battery_percent": 83
+                    },
+                    {
+                        "_id": "12:34:56:07:bb:0e",
+                        "type": "NAModule4",
+                        "module_name": "Livingroom",
+                        "data_type": [
+                            "Temperature",
+                            "CO2",
+                            "Humidity"
+                        ],
+                        "last_setup": 1548957209,
+                        "reachable": true,
+                        "dashboard_data": {
+                            "time_utc": 1559413093,
+                            "Temperature": 26.4,
+                            "CO2": 451,
+                            "Humidity": 31,
+                            "min_temp": 25.1,
+                            "max_temp": 26.4,
+                            "date_min_temp": 1559365290,
+                            "date_max_temp": 1559413093,
+                            "temp_trend": "stable"
+                        },
+                        "firmware": 44,
+                        "last_message": 1559413177,
+                        "last_seen": 1559413093,
+                        "rf_status": 84,
+                        "battery_vp": 5626,
+                        "battery_percent": 79
+                    },
+                    {
+                        "_id": "12:34:56:03:1b:e4",
+                        "type": "NAModule2",
+                        "module_name": "Garden",
+                        "data_type": [
+                            "Wind"
+                        ],
+                        "last_setup": 1549193862,
+                        "reachable": true,
+                        "dashboard_data": {
+                            "time_utc": 1559413170,
+                            "WindStrength": 4,
+                            "WindAngle": 217,
+                            "GustStrength": 9,
+                            "GustAngle": 206,
+                            "max_wind_str": 21,
+                            "max_wind_angle": 217,
+                            "date_max_wind_str": 1559386669
+                        },
+                        "firmware": 19,
+                        "last_message": 1559413177,
+                        "last_seen": 1559413177,
+                        "rf_status": 59,
+                        "battery_vp": 5689,
+                        "battery_percent": 85
+                    },
+                    {
+                        "_id": "12:34:56:05:51:20",
+                        "type": "NAModule3",
+                        "module_name": "Yard",
+                        "data_type": [
+                            "Rain"
+                        ],
+                        "last_setup": 1549194580,
+                        "reachable": true,
+                        "dashboard_data": {
+                            "time_utc": 1559413170,
+                            "Rain": 0,
+                            "sum_rain_24": 0,
+                            "sum_rain_1": 0
+                        },
+                        "firmware": 8,
+                        "last_message": 1559413177,
+                        "last_seen": 1559413170,
+                        "rf_status": 67,
+                        "battery_vp": 5860,
+                        "battery_percent": 93
+                    }
+                ]
+            },
+            {
+                "_id": "12:34:56:00:aa:01",
+                "station_name": "MyRemoteStation",
+                "date_setup": 1499189962,
+                "last_setup": 1499189962,
+                "type": "NAMain",
+                "last_status_store": 1554506294,
+                "module_name": "Indoor",
+                "firmware": 132,
+                "last_upgrade": 1499189915,
+                "wifi_status": 46,
+                "reachable": false,
+                "co2_calibrating": false,
+                "data_type": [
+                    "Temperature",
+                    "CO2",
+                    "Humidity",
+                    "Noise",
+                    "Pressure"
+                ],
+                "place": {
+                    "altitude": 6,
+                    "city": "Harstad",
+                    "country": "NO",
+                    "timezone": "Europe/Oslo",
+                    "location": [
+                        59.903781,
+                        10.683728
+                    ]
+                },
+                "modules": [
+                    {
+                        "_id": "12:34:56:00:aa:02",
+                        "type": "NAModule1",
+                        "module_name": "Outdoor",
+                        "data_type": [
+                            "Temperature",
+                            "Humidity"
+                        ],
+                        "last_setup": 1499189902,
+                        "battery_percent": 17,
+                        "reachable": false,
+                        "firmware": 44,
+                        "last_message": 1536805739,
+                        "last_seen": 1536696388,
+                        "rf_status": 87,
+                        "battery_vp": 4018,
+                        "main_device": "12:34:56:00:aa:01"
+                    },
+                    {
+                        "_id": "12:34:56:00:aa:03",
+                        "type": "NAModule2",
+                        "module_name": "Wind Gauge",
+                        "data_type": [
+                            "Wind"
+                        ],
+                        "last_setup": 1499190606,
+                        "battery_percent": 3,
+                        "reachable": false,
+                        "firmware": 18,
+                        "last_message": 1537259554,
+                        "last_seen": 1537259554,
+                        "rf_status": 74,
+                        "battery_vp": 4013,
+                        "main_device": "12:34:56:00:aa:01"
+                    }
+                ]
+            }
+        ],
+        "user": {
+            "mail": "john@doe.com",
+            "administrative": {
+                "lang": "de-DE",
+                "reg_locale": "de-DE",
+                "country": "DE",
+                "unit": 0,
+                "windunit": 0,
+                "pressureunit": 0,
+                "feel_like_algo": 0
+            }
+        }
+    },
+    "status": "ok",
+    "time_exec": 0.91107702255249,
+    "time_server": 1559413602
+}

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -90,7 +90,7 @@ class NetatmOAuth2:
 
     def refresh_tokens(self) -> Dict[str, Union[str, int]]:
         """Refresh and return new tokens."""
-        token = self._oauth.refresh_token(_AUTH_REQ)
+        token = self._oauth.refresh_token(_AUTH_REQ, **self.extra)
 
         if self.token_updater is not None:
             self.token_updater(token)

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -103,6 +103,11 @@ class NetatmOAuth2:
         if not params:
             params = {}
 
+        if "json" in params:
+            json_params = params.pop("json")
+        else:
+            json_params = None
+
         if "http://" in url:
             try:
                 resp = requests.post(url, data=params, timeout=timeout)
@@ -115,7 +120,14 @@ class NetatmOAuth2:
                     LOG.error("Too many retries")
                     return
                 try:
-                    return self._oauth.post(url=url, data=params, timeout=timeout)
+                    if json_params:
+                        rsp = self._oauth.post(
+                            url=url, json=json_params, timeout=timeout
+                        )
+                    else:
+                        rsp = self._oauth.post(url=url, data=params, timeout=timeout)
+
+                    return rsp
                 except (
                     TokenExpiredError,
                     requests.exceptions.ReadTimeout,

--- a/src/pyatmo/auth.py
+++ b/src/pyatmo/auth.py
@@ -26,6 +26,7 @@ ALL_SCOPES = [
     "write_camera",
     "read_presence",
     "access_presence",
+    "write_presence",
     "read_homecoach",
     "read_smokedetector",
     "read_thermostat",

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -790,3 +790,30 @@ class CameraData:
         ):
             return True
         return False
+
+    def set_state(self, home_id: str, camera_id: str, state: Tuple[str, str]) -> bool:
+        """Turn camera on/off.
+
+        Arguments:
+            home_id {str} -- ID of a home
+            camera_id {str} -- ID of a camera
+
+        Returns:
+            Boolean -- Success of the request
+        """
+        param, val = state
+
+        postParams = {
+            "json": {
+                "home": {"id": home_id, "modules": [{"id": camera_id, param: val}]}
+            },
+        }
+
+        resp = self.authData.post_request(url=_SETSTATE_REQ, params=postParams)
+
+        if "error" in resp:
+            LOG.debug("%s", resp)
+            return False
+
+        LOG.debug("%s", resp)
+        return True

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -81,6 +81,7 @@ class CameraData:
                         self.events[e["camera_id"]][e["time"]] = e
             for c in item["cameras"]:
                 self.cameras[homeId][c["id"]] = c
+                self.cameras[homeId][c["id"]]["home"] = homeId
                 if c["type"] == "NACamera" and "modules" in c:
                     for m in c["modules"]:
                         self.modules[m["id"]] = m
@@ -793,22 +794,25 @@ class CameraData:
 
     def set_state(
         self,
-        home_id: str,
         camera_id: str,
+        home_id: str = None,
         floodlight: str = None,
         monitoring: str = None,
     ) -> bool:
-        """Turn camera on/off.
+        """Turn camera (light) on/off.
 
         Arguments:
-            home_id {str} -- ID of a home
             camera_id {str} -- ID of a camera
+            home_id {str} -- ID of a home
             floodlight {str} -- Mode for floodlight (on/auto)
             monitoring {str} -- Mode for monitoring (on/off)
 
         Returns:
             Boolean -- Success of the request
         """
+        if home_id is None:
+            home_id = self.get_camera(camera_id)["home"]
+
         module = {"id": camera_id}
 
         if floodlight:

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -814,8 +814,14 @@ class CameraData:
             return False
         elif floodlight:
             param, val = "floodlight", floodlight.lower()
+            if val not in ["on", "auto"]:
+                LOG.error("Invalid value für floodlight")
+                return False
         elif monitoring:
             param, val = "monitoring", monitoring.lower()
+            if val not in ["on", "off"]:
+                LOG.error("Invalid value für monitoring")
+                return False
 
         postParams = {
             "json": {
@@ -826,7 +832,7 @@ class CameraData:
         try:
             resp = self.authData.post_request(url=_SETSTATE_REQ, params=postParams)
         except ApiError as err_msg:
-            LOG.error(err_msg)
+            LOG.error("%s", err_msg)
             return False
 
         if "error" in resp:

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -840,5 +840,4 @@ class CameraData:
             return False
 
         LOG.debug("%s", resp)
-        print(resp)
         return True

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -791,17 +791,31 @@ class CameraData:
             return True
         return False
 
-    def set_state(self, home_id: str, camera_id: str, state: Tuple[str, str]) -> bool:
+    def set_state(
+        self,
+        home_id: str,
+        camera_id: str,
+        floodlight: str = None,
+        monitoring: str = None,
+    ) -> bool:
         """Turn camera on/off.
 
         Arguments:
             home_id {str} -- ID of a home
             camera_id {str} -- ID of a camera
+            floodlight {str} -- Mode for floodlight (on/auto)
+            monitoring {str} -- Mode for monitoring (on/off)
 
         Returns:
             Boolean -- Success of the request
         """
-        param, val = state
+        if floodlight and monitoring:
+            LOG.error("You can only set on of either states")
+            return False
+        elif floodlight:
+            param, val = "floodlight", floodlight.lower()
+        elif monitoring:
+            param, val = "monitoring", monitoring.lower()
 
         postParams = {
             "json": {
@@ -809,7 +823,11 @@ class CameraData:
             },
         }
 
-        resp = self.authData.post_request(url=_SETSTATE_REQ, params=postParams)
+        try:
+            resp = self.authData.post_request(url=_SETSTATE_REQ, params=postParams)
+        except ApiError as err_msg:
+            LOG.error(err_msg)
+            return False
 
         if "error" in resp:
             LOG.debug("%s", resp)

--- a/src/pyatmo/camera.py
+++ b/src/pyatmo/camera.py
@@ -809,24 +809,24 @@ class CameraData:
         Returns:
             Boolean -- Success of the request
         """
-        if floodlight and monitoring:
-            LOG.error("You can only set on of either states")
-            return False
-        elif floodlight:
+        module = {"id": camera_id}
+
+        if floodlight:
             param, val = "floodlight", floodlight.lower()
             if val not in ["on", "auto"]:
                 LOG.error("Invalid value für floodlight")
-                return False
-        elif monitoring:
+            else:
+                module[param] = val
+
+        if monitoring:
             param, val = "monitoring", monitoring.lower()
             if val not in ["on", "off"]:
                 LOG.error("Invalid value für monitoring")
-                return False
+            else:
+                module[param] = val
 
         postParams = {
-            "json": {
-                "home": {"id": home_id, "modules": [{"id": camera_id, param: val}]}
-            },
+            "json": {"home": {"id": home_id, "modules": [module]}},
         }
 
         try:
@@ -840,4 +840,5 @@ class CameraData:
             return False
 
         LOG.debug("%s", resp)
+        print(resp)
         return True

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -409,6 +409,7 @@ def test_CameraData_smokedetectorByName(cameraHomeData, name, home, home_id, exp
             "camera_set_state_ok.json",
             True,
         ),
+        (None, "12:34:56:00:f1:62", None, "on", "camera_set_state_ok.json", True,),
         (
             "91763b24c43d3e344f424e8b",
             "12:34:56:00:f1:62",

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -388,3 +388,45 @@ def test_CameraData_smokedetectorByName(cameraHomeData, name, home, home_id, exp
         )
     else:
         assert cameraHomeData.smokedetectorByName(name, home, home_id)["id"] == expected
+
+
+@pytest.mark.parametrize(
+    "home_id, camera_id, floodlight, monitoring, json_fixture, expected",
+    [
+        (None, None, None, None, "camera_set_state_error.json", False),
+        (
+            "91763b24c43d3e344f424e8b",
+            "12:34:56:00:f1:62",
+            None,
+            "on",
+            "camera_set_state_ok.json",
+            True,
+        ),
+    ],
+)
+def test_CameraData_set_state(
+    cameraHomeData,
+    requests_mock,
+    home_id,
+    camera_id,
+    floodlight,
+    monitoring,
+    json_fixture,
+    expected,
+):
+    with open("fixtures/%s" % json_fixture) as f:
+        json_fixture = json.load(f)
+    requests_mock.post(
+        pyatmo.camera._SETSTATE_REQ,
+        json=json_fixture,
+        headers={"content-type": "application/json"},
+    )
+    assert (
+        cameraHomeData.set_state(
+            home_id=home_id,
+            camera_id=camera_id,
+            floodlight=floodlight,
+            monitoring=monitoring,
+        )
+        == expected
+    )

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -417,6 +417,14 @@ def test_CameraData_smokedetectorByName(cameraHomeData, name, home, home_id, exp
             "camera_set_state_error_already_on.json",
             True,
         ),
+        (
+            "91763b24c43d3e344f424e8b",
+            "12:34:56:00:f1:62",
+            "on",
+            None,
+            "camera_set_state_error_wrong_parameter.json",
+            False,
+        ),
     ],
 )
 def test_CameraData_set_state(

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -412,6 +412,14 @@ def test_CameraData_smokedetectorByName(cameraHomeData, name, home, home_id, exp
         (
             "91763b24c43d3e344f424e8b",
             "12:34:56:00:f1:62",
+            "auto",
+            "on",
+            "camera_set_state_ok.json",
+            True,
+        ),
+        (
+            "91763b24c43d3e344f424e8b",
+            "12:34:56:00:f1:62",
             None,
             "on",
             "camera_set_state_error_already_on.json",

--- a/tests/test_pyatmo_camera.py
+++ b/tests/test_pyatmo_camera.py
@@ -393,13 +393,28 @@ def test_CameraData_smokedetectorByName(cameraHomeData, name, home, home_id, exp
 @pytest.mark.parametrize(
     "home_id, camera_id, floodlight, monitoring, json_fixture, expected",
     [
-        (None, None, None, None, "camera_set_state_error.json", False),
+        (
+            "91763b24c43d3e344f424e8b",
+            "12:34:56:00:f1:ff",
+            "on",
+            None,
+            "camera_set_state_error.json",
+            False,
+        ),
         (
             "91763b24c43d3e344f424e8b",
             "12:34:56:00:f1:62",
             None,
             "on",
             "camera_set_state_ok.json",
+            True,
+        ),
+        (
+            "91763b24c43d3e344f424e8b",
+            "12:34:56:00:f1:62",
+            None,
+            "on",
+            "camera_set_state_error_already_on.json",
             True,
         ),
     ],


### PR DESCRIPTION
This adds the `setstate` call to turn the presence floodlights on or in auto mode and enables/disables motion detection for cameras.

It also fixes an issue with refreshing the oauth2 token.