### PR TITLE
Fix station name

### DIFF
--- a/fixtures/weatherstation_data_simple.json
+++ b/fixtures/weatherstation_data_simple.json
@@ -272,7 +272,7 @@
             },
             {
                 "_id": "12:34:56:32:a7:60",
-                "station_name": "Ateljen",
+                "home_name": "Ateljen",
                 "date_setup": 1566714693,
                 "last_setup": 1566714693,
                 "type": "NAMain",

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -47,6 +47,8 @@ class WeatherStationData:
         self.modules = {}
 
         for item in self.raw_data:
+            if "station_name" not in item:
+                item["station_name"] = item.get("home_name", item["type"])
 
             if "modules" not in item:
                 item["modules"] = [item]

--- a/src/pyatmo/weather_station.py
+++ b/src/pyatmo/weather_station.py
@@ -47,6 +47,7 @@ class WeatherStationData:
         self.modules = {}
 
         for item in self.raw_data:
+            # The station name is sometimes not contained in the backend data
             if "station_name" not in item:
                 item["station_name"] = item.get("home_name", item["type"])
 


### PR DESCRIPTION
When station name is not contained in the data from the Netatmo backend set it to either the home name or at least the device type.